### PR TITLE
Bump svelte and rollup-plugin-svelte versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
         "rollup": "^2.3.4",
         "rollup-plugin-livereload": "^2.0.0",
         "rollup-plugin-postcss": "^3.1.8",
-        "rollup-plugin-svelte": "^6.0.0",
+        "rollup-plugin-svelte": "^6.1.1",
         "rollup-plugin-terser": "^7.0.0",
         "rollup-plugin-workbox": "^6.2.0",
-        "svelte": "^3.0.0",
+        "svelte": "^3.50.1",
         "svelte-routing": "^1.6.0"
       }
     },
@@ -8469,9 +8469,9 @@
       }
     },
     "node_modules/rollup-plugin-svelte": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.0.0.tgz",
-      "integrity": "sha512-y9qtWa+iNYwXdOZqaEqz3i6k3gzofC9JXzv+WVKDOt0DLiJxJaSrlKKf4YkKG91RzTK5Lo+0fW8in9QH/DxEhA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "dependencies": {
         "require-relative": "^0.8.7",
@@ -9152,9 +9152,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.1.tgz",
-      "integrity": "sha512-OX/IBVUJSFo1rnznXdwf9rv6LReJ3qQ0PwRjj76vfUWyTfbHbR9OXqJBnUrpjyis2dwYcbT2Zm1DFjOOF1ZbbQ==",
+      "version": "3.50.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
+      "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -16831,9 +16831,9 @@
       }
     },
     "rollup-plugin-svelte": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.0.0.tgz",
-      "integrity": "sha512-y9qtWa+iNYwXdOZqaEqz3i6k3gzofC9JXzv+WVKDOt0DLiJxJaSrlKKf4YkKG91RzTK5Lo+0fW8in9QH/DxEhA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "requires": {
         "require-relative": "^0.8.7",
@@ -17372,9 +17372,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.1.tgz",
-      "integrity": "sha512-OX/IBVUJSFo1rnznXdwf9rv6LReJ3qQ0PwRjj76vfUWyTfbHbR9OXqJBnUrpjyis2dwYcbT2Zm1DFjOOF1ZbbQ==",
+      "version": "3.50.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
+      "integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
       "dev": true
     },
     "svelte-routing": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "rollup": "^2.3.4",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-postcss": "^3.1.8",
-    "rollup-plugin-svelte": "^6.0.0",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^7.0.0",
     "rollup-plugin-workbox": "^6.2.0",
-    "svelte": "^3.0.0",
+    "svelte": "^3.50.1",
     "svelte-routing": "^1.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
## What does this PR do?
Bump svelte to 3.50.1 and rollup-plugin-svelte to 6.1.1

## Types of changes
- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Documentation
 - [ ] Update docs

## Testing
- [ ] Add new tests that cover the feature/fix this PR adds
- [ ] Update existing tests to cover the feature/fix this PR adds

## Screenshots (if appropriate):